### PR TITLE
Add timestamp feature to stdin and stdout streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "cfg-if"
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "nix"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,4 +68,34 @@ version = "0.1.0"
 dependencies = [
  "fork",
  "nix",
+ "regex",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
@@ -30,6 +60,131 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "fork"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,10 +194,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
@@ -63,12 +276,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "qrun"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "fork",
  "nix",
  "regex",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -99,3 +400,243 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,46 @@
 version = 4
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "cc"
+version = "1.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -21,6 +57,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "fork"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,10 +86,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "nix"
@@ -48,9 +144,189 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "qrun"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "fork",
  "nix",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "syn"
+version = "2.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,46 +3,10 @@
 version = 4
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "bumpalo"
-version = "3.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
-
-[[package]]
-name = "cc"
-version = "1.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
-dependencies = [
- "shlex",
-]
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "cfg-if"
@@ -57,26 +21,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-link",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "fork"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,50 +30,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
-
-[[package]]
-name = "log"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "nix"
@@ -144,189 +48,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
 name = "qrun"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "fork",
  "nix",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
-name = "rustversion"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "syn"
-version = "2.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
-
-[[package]]
-name = "windows-result"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
-dependencies = [
- "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,8 @@ nix = { version = "0.29.0", features = ["signal", "process"] }
 
 [dev-dependencies]
 regex = "1.10.3"
+criterion = "0.5.1"
+
+[[bench]]
+name = "timestamp_benchmark"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 fork = "0.2.0"
 nix = { version = "0.29.0", features = ["signal", "process"] }
+chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 fork = "0.2.0"
 nix = { version = "0.29.0", features = ["signal", "process"] }
+
+[dev-dependencies]
+regex = "1.10.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2021"
 [dependencies]
 fork = "0.2.0"
 nix = { version = "0.29.0", features = ["signal", "process"] }
-chrono = "0.4"

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,39 @@
+# Qrun Benchmarks
+
+This directory contains benchmarks for measuring the performance overhead of the timestamp functionality in qrun.
+
+## Running the Benchmarks
+
+To run the benchmarks, use the provided script:
+
+```bash
+./scripts/run_benchmarks.sh
+```
+
+This will:
+1. Build qrun in release mode
+2. Run all benchmarks
+3. Generate a summary report in `benchmark_summary.md`
+
+## Benchmark Categories
+
+The benchmarks are divided into several categories:
+
+1. **Direct Command Execution**: Measures the performance of running commands directly without qrun.
+2. **Qrun Command Execution**: Measures the performance of running commands through qrun with timestamp functionality.
+3. **Command Comparison**: Directly compares the performance of direct commands vs. qrun commands for different output sizes.
+4. **Stdin Processing**: Compares the performance of stdin processing with and without qrun.
+
+## Output Sizes
+
+The benchmarks test different output sizes:
+
+- **Small**: Single line output (e.g., "Hello, World!")
+- **Medium**: 100 lines of output
+- **Large**: 1000 lines of output
+
+## Interpreting Results
+
+The benchmark results will show the time taken for each command execution and the overhead introduced by the timestamp functionality. The overhead is calculated as a percentage increase in execution time compared to running the command directly.
+
+For most interactive use cases, this overhead should be negligible compared to the benefits of having timestamped output.

--- a/benches/timestamp_benchmark.rs
+++ b/benches/timestamp_benchmark.rs
@@ -1,0 +1,227 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
+use std::process::{Command, Stdio};
+use std::io::{BufRead, BufReader, Write};
+use std::time::{Duration, Instant};
+
+fn benchmark_direct_command(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Command Execution");
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(10));
+
+    // Benchmark for small output (single line)
+    group.bench_function("direct_command_small", |b| {
+        b.iter(|| {
+            let output = Command::new("echo")
+                .arg("Hello, World!")
+                .output()
+                .expect("Failed to execute command");
+            black_box(output);
+        });
+    });
+
+    // Benchmark for medium output (100 lines)
+    group.bench_function("direct_command_medium", |b| {
+        b.iter(|| {
+            let output = Command::new("bash")
+                .arg("-c")
+                .arg("for i in {1..100}; do echo \"Line $i\"; done")
+                .output()
+                .expect("Failed to execute command");
+            black_box(output);
+        });
+    });
+
+    // Benchmark for large output (1000 lines)
+    group.bench_function("direct_command_large", |b| {
+        b.iter(|| {
+            let output = Command::new("bash")
+                .arg("-c")
+                .arg("for i in {1..1000}; do echo \"Line $i\"; done")
+                .output()
+                .expect("Failed to execute command");
+            black_box(output);
+        });
+    });
+
+    group.finish();
+}
+
+fn benchmark_qrun_command(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Qrun Command Execution");
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(10));
+
+    // Benchmark for small output (single line)
+    group.bench_function("qrun_command_small", |b| {
+        b.iter(|| {
+            let output = Command::new("target/release/qrun")
+                .arg("echo")
+                .arg("Hello, World!")
+                .output()
+                .expect("Failed to execute command");
+            black_box(output);
+        });
+    });
+
+    // Benchmark for medium output (100 lines)
+    group.bench_function("qrun_command_medium", |b| {
+        b.iter(|| {
+            let output = Command::new("target/release/qrun")
+                .arg("bash")
+                .arg("-c")
+                .arg("for i in {1..100}; do echo \"Line $i\"; done")
+                .output()
+                .expect("Failed to execute command");
+            black_box(output);
+        });
+    });
+
+    // Benchmark for large output (1000 lines)
+    group.bench_function("qrun_command_large", |b| {
+        b.iter(|| {
+            let output = Command::new("target/release/qrun")
+                .arg("bash")
+                .arg("-c")
+                .arg("for i in {1..1000}; do echo \"Line $i\"; done")
+                .output()
+                .expect("Failed to execute command");
+            black_box(output);
+        });
+    });
+
+    group.finish();
+}
+
+fn benchmark_comparison(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Command Comparison");
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(10));
+
+    for size in ["small", "medium", "large"].iter() {
+        let cmd_args = match *size {
+            "small" => vec!["echo", "Hello, World!"],
+            "medium" => vec!["bash", "-c", "for i in {1..100}; do echo \"Line $i\"; done"],
+            "large" => vec!["bash", "-c", "for i in {1..1000}; do echo \"Line $i\"; done"],
+            _ => unreachable!(),
+        };
+
+        group.bench_with_input(BenchmarkId::new("direct", size), &cmd_args, |b, args| {
+            b.iter(|| {
+                let mut cmd = Command::new(args[0]);
+                for arg in &args[1..] {
+                    cmd.arg(arg);
+                }
+                let output = cmd.output().expect("Failed to execute command");
+                black_box(output);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("qrun", size), &cmd_args, |b, args| {
+            b.iter(|| {
+                let mut cmd = Command::new("target/release/qrun");
+                for arg in args.iter() {
+                    cmd.arg(arg);
+                }
+                let output = cmd.output().expect("Failed to execute command");
+                black_box(output);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn benchmark_stdin_processing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Stdin Processing");
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(10));
+
+    // Benchmark for small input (single line)
+    group.bench_function("direct_stdin_small", |b| {
+        b.iter(|| {
+            let mut child = Command::new("cat")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .expect("Failed to spawn command");
+            
+            let mut stdin = child.stdin.take().expect("Failed to open stdin");
+            stdin.write_all(b"Hello, World!\n").expect("Failed to write to stdin");
+            drop(stdin);
+            
+            let output = child.wait_with_output().expect("Failed to wait for command");
+            black_box(output);
+        });
+    });
+
+    // Benchmark for small input with qrun (single line)
+    group.bench_function("qrun_stdin_small", |b| {
+        b.iter(|| {
+            let mut child = Command::new("target/release/qrun")
+                .arg("cat")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .expect("Failed to spawn command");
+            
+            let mut stdin = child.stdin.take().expect("Failed to open stdin");
+            stdin.write_all(b"Hello, World!\n").expect("Failed to write to stdin");
+            drop(stdin);
+            
+            let output = child.wait_with_output().expect("Failed to wait for command");
+            black_box(output);
+        });
+    });
+
+    // Benchmark for medium input (100 lines)
+    group.bench_function("direct_stdin_medium", |b| {
+        b.iter(|| {
+            let mut child = Command::new("cat")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .expect("Failed to spawn command");
+            
+            let mut stdin = child.stdin.take().expect("Failed to open stdin");
+            for i in 1..=100 {
+                writeln!(stdin, "Line {}", i).expect("Failed to write to stdin");
+            }
+            drop(stdin);
+            
+            let output = child.wait_with_output().expect("Failed to wait for command");
+            black_box(output);
+        });
+    });
+
+    // Benchmark for medium input with qrun (100 lines)
+    group.bench_function("qrun_stdin_medium", |b| {
+        b.iter(|| {
+            let mut child = Command::new("target/release/qrun")
+                .arg("cat")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .expect("Failed to spawn command");
+            
+            let mut stdin = child.stdin.take().expect("Failed to open stdin");
+            for i in 1..=100 {
+                writeln!(stdin, "Line {}", i).expect("Failed to write to stdin");
+            }
+            drop(stdin);
+            
+            let output = child.wait_with_output().expect("Failed to wait for command");
+            black_box(output);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    benchmark_direct_command,
+    benchmark_qrun_command,
+    benchmark_comparison,
+    benchmark_stdin_processing
+);
+criterion_main!(benches);

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Build the release version for benchmarking
+cargo build --release
+
+# Run the benchmarks
+cargo bench
+
+# Generate a summary report
+echo "Benchmark Summary Report" > benchmark_summary.md
+echo "=======================" >> benchmark_summary.md
+echo "" >> benchmark_summary.md
+echo "## Overview" >> benchmark_summary.md
+echo "" >> benchmark_summary.md
+echo "This report compares the performance of running commands directly versus using qrun with timestamp functionality." >> benchmark_summary.md
+echo "" >> benchmark_summary.md
+
+# Extract and format the benchmark results
+echo "## Results" >> benchmark_summary.md
+echo "" >> benchmark_summary.md
+echo "### Command Execution Comparison" >> benchmark_summary.md
+echo "" >> benchmark_summary.md
+echo "| Test Case | Direct Command | Qrun Command | Overhead |" >> benchmark_summary.md
+echo "|-----------|---------------|--------------|----------|" >> benchmark_summary.md
+
+# Parse the benchmark results
+BENCH_DIR="target/criterion/Command Comparison"
+for size in small medium large; do
+    direct_time=$(grep -A 3 "time:" "$BENCH_DIR/direct/$size/new/estimates.json" | grep "mean" | awk '{print $2}' | tr -d ',')
+    qrun_time=$(grep -A 3 "time:" "$BENCH_DIR/qrun/$size/new/estimates.json" | grep "mean" | awk '{print $2}' | tr -d ',')
+    
+    # Calculate overhead percentage
+    overhead=$(echo "scale=2; ($qrun_time - $direct_time) / $direct_time * 100" | bc)
+    
+    # Convert to milliseconds for better readability
+    direct_ms=$(echo "scale=3; $direct_time * 1000" | bc)
+    qrun_ms=$(echo "scale=3; $qrun_time * 1000" | bc)
+    
+    echo "| $size | ${direct_ms}ms | ${qrun_ms}ms | ${overhead}% |" >> benchmark_summary.md
+done
+
+echo "" >> benchmark_summary.md
+echo "### Stdin Processing Comparison" >> benchmark_summary.md
+echo "" >> benchmark_summary.md
+echo "| Test Case | Direct Command | Qrun Command | Overhead |" >> benchmark_summary.md
+echo "|-----------|---------------|--------------|----------|" >> benchmark_summary.md
+
+# Parse the stdin benchmark results
+BENCH_DIR="target/criterion/Stdin Processing"
+for size in small medium; do
+    direct_time=$(grep -A 3 "time:" "$BENCH_DIR/direct_stdin_$size/new/estimates.json" | grep "mean" | awk '{print $2}' | tr -d ',')
+    qrun_time=$(grep -A 3 "time:" "$BENCH_DIR/qrun_stdin_$size/new/estimates.json" | grep "mean" | awk '{print $2}' | tr -d ',')
+    
+    # Calculate overhead percentage
+    overhead=$(echo "scale=2; ($qrun_time - $direct_time) / $direct_time * 100" | bc)
+    
+    # Convert to milliseconds for better readability
+    direct_ms=$(echo "scale=3; $direct_time * 1000" | bc)
+    qrun_ms=$(echo "scale=3; $qrun_time * 1000" | bc)
+    
+    echo "| $size | ${direct_ms}ms | ${qrun_ms}ms | ${overhead}% |" >> benchmark_summary.md
+done
+
+echo "" >> benchmark_summary.md
+echo "## Conclusion" >> benchmark_summary.md
+echo "" >> benchmark_summary.md
+echo "The benchmark results show the performance overhead introduced by the timestamp functionality in qrun." >> benchmark_summary.md
+echo "This overhead includes:" >> benchmark_summary.md
+echo "" >> benchmark_summary.md
+echo "1. Forking process overhead" >> benchmark_summary.md
+echo "2. Timestamp generation and formatting" >> benchmark_summary.md
+echo "3. Stream processing and line buffering" >> benchmark_summary.md
+echo "" >> benchmark_summary.md
+echo "For most interactive use cases, this overhead should be negligible compared to the benefits of having timestamped output." >> benchmark_summary.md
+
+echo "Benchmark summary report generated: benchmark_summary.md"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use chrono::Utc;
 use nix::libc::c_int;
 use nix::sys::signal::{self, sigaction, SigAction, SigHandler, SigSet, Signal};
 use nix::unistd::Pid;
@@ -7,126 +6,128 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 static mut CHILD_PID: Pid = Pid::from_raw(-1);
 const UNCHECKED_SIGNALS: [Signal; 5] = [
-	Signal::SIGTTIN,
-	Signal::SIGKILL,
-	Signal::SIGSTOP,
-	Signal::SIGCHLD,
-	Signal::SIGSEGV,
+        Signal::SIGTTIN,
+        Signal::SIGKILL,
+        Signal::SIGSTOP,
+        Signal::SIGCHLD,
+        Signal::SIGSEGV,
 ];
 
 extern "C" fn handle_signal(signum: c_int) {
-	unsafe {
-		assert!(CHILD_PID.as_raw() != -1, "child pid not set!");
-		let signal = std::mem::transmute::<i32, Signal>(signum as i32);
-		let _ = signal::kill(CHILD_PID, signal);
-	}
+        unsafe {
+                assert!(CHILD_PID.as_raw() != -1, "child pid not set!");
+                let signal = std::mem::transmute::<i32, Signal>(signum as i32);
+                let _ = signal::kill(CHILD_PID, signal);
+        }
 }
 
 fn get_timestamp() -> String {
-	let now = Utc::now();
-	format!("[{}] ", now.timestamp())
+        let now = SystemTime::now();
+        let since_epoch = now.duration_since(UNIX_EPOCH).expect("Time went backwards");
+        format!("[{}] ", since_epoch.as_secs())
 }
 
 fn process_stream<R: BufRead, W: Write>(reader: R, mut writer: W) {
-	for line in reader.lines() {
-		if let Ok(line) = line {
-			let timestamp = get_timestamp();
-			let _ = writeln!(writer, "{}{}", timestamp, line);
-		}
-	}
+        for line in reader.lines() {
+                if let Ok(line) = line {
+                        let timestamp = get_timestamp();
+                        let _ = writeln!(writer, "{}{}", timestamp, line);
+                }
+        }
 }
 
 fn main() {
-	let args: Vec<String> = args().skip(1).collect();
+        let args: Vec<String> = args().skip(1).collect();
 
-	if args.is_empty() {
-		eprintln!("Usage: qrun <command> [args...]");
-		std::process::exit(1);
-	}
+        if args.is_empty() {
+                eprintln!("Usage: qrun <command> [args...]");
+                std::process::exit(1);
+        }
 
-	// Create a command with piped stdin/stdout/stderr
-	let mut cmd = Command::new(&args[0]);
-	if args.len() > 1 {
-		cmd.args(&args[1..]);
-	}
+        // Create a command with piped stdin/stdout/stderr
+        let mut cmd = Command::new(&args[0]);
+        if args.len() > 1 {
+                cmd.args(&args[1..]);
+        }
 
-	cmd.stdin(Stdio::piped())
-		.stdout(Stdio::piped())
-		.stderr(Stdio::piped());
+        cmd.stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
 
-	match cmd.spawn() {
-		Ok(mut child) => {
-			unsafe {
-				CHILD_PID = Pid::from_raw(child.id() as i32);
-			}
+        match cmd.spawn() {
+                Ok(mut child) => {
+                        unsafe {
+                                CHILD_PID = Pid::from_raw(child.id() as i32);
+                        }
 
-			let handler = SigHandler::Handler(handle_signal);
+                        let handler = SigHandler::Handler(handle_signal);
 
-			for sig in Signal::iterator() {
-				if UNCHECKED_SIGNALS.contains(&sig) {
-					continue;
-				}
+                        for sig in Signal::iterator() {
+                                if UNCHECKED_SIGNALS.contains(&sig) {
+                                        continue;
+                                }
 
-				unsafe {
-					let _ = sigaction(
-						sig,
-						&SigAction::new(handler, signal::SaFlags::empty(), SigSet::empty()),
-					);
-				}
-			}
+                                unsafe {
+                                        let _ = sigaction(
+                                                sig,
+                                                &SigAction::new(handler, signal::SaFlags::empty(), SigSet::empty()),
+                                        );
+                                }
+                        }
 
-			// Handle stdin
-			let stdin = child.stdin.take();
-			if let Some(stdin) = stdin {
-				let stdin_mutex = Arc::new(Mutex::new(stdin));
-				let stdin_clone = Arc::clone(&stdin_mutex);
+                        // Handle stdin
+                        let stdin = child.stdin.take();
+                        if let Some(stdin) = stdin {
+                                let stdin_mutex = Arc::new(Mutex::new(stdin));
+                                let stdin_clone = Arc::clone(&stdin_mutex);
 
-				thread::spawn(move || {
-					let stdin = io::stdin();
-					let reader = stdin.lock();
+                                thread::spawn(move || {
+                                        let stdin = io::stdin();
+                                        let reader = stdin.lock();
 
-					for line in reader.lines() {
-						if let Ok(line) = line {
-							if let Ok(mut child_stdin) = stdin_clone.lock() {
-								let timestamp = get_timestamp();
-								let _ = writeln!(child_stdin, "{}{}", timestamp, line);
-							}
-						}
-					}
-				});
-			}
+                                        for line in reader.lines() {
+                                                if let Ok(line) = line {
+                                                        if let Ok(mut child_stdin) = stdin_clone.lock() {
+                                                                let timestamp = get_timestamp();
+                                                                let _ = writeln!(child_stdin, "{}{}", timestamp, line);
+                                                        }
+                                                }
+                                        }
+                                });
+                        }
 
-			// Handle stdout
-			if let Some(stdout) = child.stdout.take() {
-				let stdout_reader = BufReader::new(stdout);
-				thread::spawn(move || {
-					process_stream(stdout_reader, io::stdout());
-				});
-			}
+                        // Handle stdout
+                        if let Some(stdout) = child.stdout.take() {
+                                let stdout_reader = BufReader::new(stdout);
+                                thread::spawn(move || {
+                                        process_stream(stdout_reader, io::stdout());
+                                });
+                        }
 
-			// Handle stderr
-			if let Some(stderr) = child.stderr.take() {
-				let stderr_reader = BufReader::new(stderr);
-				thread::spawn(move || {
-					process_stream(stderr_reader, io::stderr());
-				});
-			}
+                        // Handle stderr
+                        if let Some(stderr) = child.stderr.take() {
+                                let stderr_reader = BufReader::new(stderr);
+                                thread::spawn(move || {
+                                        process_stream(stderr_reader, io::stderr());
+                                });
+                        }
 
-			// Wait for the child process to complete
-			match child.wait() {
-				Ok(status) => std::process::exit(status.code().unwrap_or(1)),
-				Err(e) => {
-					eprintln!("Failed to wait for child process: {}", e);
-					std::process::exit(1);
-				}
-			}
-		}
-		Err(e) => {
-			eprintln!("Failed to execute command: {}", e);
-			std::process::exit(1);
-		}
-	}
+                        // Wait for the child process to complete
+                        match child.wait() {
+                                Ok(status) => std::process::exit(status.code().unwrap_or(1)),
+                                Err(e) => {
+                                        eprintln!("Failed to wait for child process: {}", e);
+                                        std::process::exit(1);
+                                }
+                        }
+                }
+                Err(e) => {
+                        eprintln!("Failed to execute command: {}", e);
+                        std::process::exit(1);
+                }
+        }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,17 +25,17 @@ extern "C" fn handle_signal(signum: c_int) {
 	}
 }
 
-fn get_timestamp() -> String {
+fn get_unix_timestamp() -> u64 {
 	let now = SystemTime::now();
 	let since_epoch = now.duration_since(UNIX_EPOCH).expect("Time went backwards");
-	format!("[{}] ", since_epoch.as_secs())
+	since_epoch.as_secs()
 }
 
 fn process_stream<R: BufRead, W: Write>(reader: R, mut writer: W) {
 	for line in reader.lines() {
 		if let Ok(line) = line {
-			let timestamp = get_timestamp();
-			let _ = writeln!(writer, "{}{}", timestamp, line);
+			let timestamp = get_unix_timestamp();
+			let _ = writeln!(writer, "[{}] {}", timestamp, line);
 		}
 	}
 }
@@ -92,8 +92,8 @@ fn main() {
 					for line in reader.lines() {
 						if let Ok(line) = line {
 							if let Ok(mut child_stdin) = stdin_clone.lock() {
-								let timestamp = get_timestamp();
-								let _ = writeln!(child_stdin, "{}{}", timestamp, line);
+								let timestamp = get_unix_timestamp();
+								let _ = writeln!(child_stdin, "[{}] {}", timestamp, line);
 							}
 						}
 					}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use nix::libc::c_int;
 use nix::sys::signal::{self, sigaction, SigAction, SigHandler, SigSet, Signal};
 use nix::unistd::Pid;
@@ -6,121 +7,126 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use chrono::Utc;
 
 static mut CHILD_PID: Pid = Pid::from_raw(-1);
-const UNCHECKED_SIGNALS: [Signal; 5] = [Signal::SIGTTIN, Signal::SIGKILL, Signal::SIGSTOP, Signal::SIGCHLD, Signal::SIGSEGV];
+const UNCHECKED_SIGNALS: [Signal; 5] = [
+	Signal::SIGTTIN,
+	Signal::SIGKILL,
+	Signal::SIGSTOP,
+	Signal::SIGCHLD,
+	Signal::SIGSEGV,
+];
 
 extern "C" fn handle_signal(signum: c_int) {
-        unsafe {
-                assert!(CHILD_PID.as_raw() != -1, "child pid not set!");
-                let signal = std::mem::transmute::<i32, Signal>(signum as i32);
-                let _ = signal::kill(CHILD_PID, signal);
-        }
+	unsafe {
+		assert!(CHILD_PID.as_raw() != -1, "child pid not set!");
+		let signal = std::mem::transmute::<i32, Signal>(signum as i32);
+		let _ = signal::kill(CHILD_PID, signal);
+	}
 }
 
 fn get_timestamp() -> String {
-    let now = Utc::now();
-    format!("[{}] ", now.timestamp())
+	let now = Utc::now();
+	format!("[{}] ", now.timestamp())
 }
 
 fn process_stream<R: BufRead, W: Write>(reader: R, mut writer: W) {
-    for line in reader.lines() {
-        if let Ok(line) = line {
-            let timestamp = get_timestamp();
-            let _ = writeln!(writer, "{}{}", timestamp, line);
-        }
-    }
+	for line in reader.lines() {
+		if let Ok(line) = line {
+			let timestamp = get_timestamp();
+			let _ = writeln!(writer, "{}{}", timestamp, line);
+		}
+	}
 }
 
 fn main() {
-        let args: Vec<String> = args().skip(1).collect();
+	let args: Vec<String> = args().skip(1).collect();
 
-        if args.is_empty() {
-            eprintln!("Usage: qrun <command> [args...]");
-            std::process::exit(1);
-        }
+	if args.is_empty() {
+		eprintln!("Usage: qrun <command> [args...]");
+		std::process::exit(1);
+	}
 
-        // Create a command with piped stdin/stdout/stderr
-        let mut cmd = Command::new(&args[0]);
-        if args.len() > 1 {
-            cmd.args(&args[1..]);
-        }
-        
-        cmd.stdin(Stdio::piped())
-           .stdout(Stdio::piped())
-           .stderr(Stdio::piped());
+	// Create a command with piped stdin/stdout/stderr
+	let mut cmd = Command::new(&args[0]);
+	if args.len() > 1 {
+		cmd.args(&args[1..]);
+	}
 
-        match cmd.spawn() {
-            Ok(mut child) => {
-                unsafe {
-                    CHILD_PID = Pid::from_raw(child.id() as i32);
-                }
+	cmd.stdin(Stdio::piped())
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped());
 
-                let handler = SigHandler::Handler(handle_signal);
+	match cmd.spawn() {
+		Ok(mut child) => {
+			unsafe {
+				CHILD_PID = Pid::from_raw(child.id() as i32);
+			}
 
-                for sig in Signal::iterator() {
-                    if UNCHECKED_SIGNALS.contains(&sig) {
-                        continue;
-                    }
+			let handler = SigHandler::Handler(handle_signal);
 
-                    unsafe {
-                        let _ = sigaction(
-                            sig,
-                            &SigAction::new(handler, signal::SaFlags::empty(), SigSet::empty()),
-                        );
-                    }
-                }
+			for sig in Signal::iterator() {
+				if UNCHECKED_SIGNALS.contains(&sig) {
+					continue;
+				}
 
-                // Handle stdin
-                let stdin = child.stdin.take();
-                if let Some(stdin) = stdin {
-                    let stdin_mutex = Arc::new(Mutex::new(stdin));
-                    let stdin_clone = Arc::clone(&stdin_mutex);
-                    
-                    thread::spawn(move || {
-                        let stdin = io::stdin();
-                        let reader = stdin.lock();
-                        
-                        for line in reader.lines() {
-                            if let Ok(line) = line {
-                                if let Ok(mut child_stdin) = stdin_clone.lock() {
-                                    let timestamp = get_timestamp();
-                                    let _ = writeln!(child_stdin, "{}{}", timestamp, line);
-                                }
-                            }
-                        }
-                    });
-                }
+				unsafe {
+					let _ = sigaction(
+						sig,
+						&SigAction::new(handler, signal::SaFlags::empty(), SigSet::empty()),
+					);
+				}
+			}
 
-                // Handle stdout
-                if let Some(stdout) = child.stdout.take() {
-                    let stdout_reader = BufReader::new(stdout);
-                    thread::spawn(move || {
-                        process_stream(stdout_reader, io::stdout());
-                    });
-                }
+			// Handle stdin
+			let stdin = child.stdin.take();
+			if let Some(stdin) = stdin {
+				let stdin_mutex = Arc::new(Mutex::new(stdin));
+				let stdin_clone = Arc::clone(&stdin_mutex);
 
-                // Handle stderr
-                if let Some(stderr) = child.stderr.take() {
-                    let stderr_reader = BufReader::new(stderr);
-                    thread::spawn(move || {
-                        process_stream(stderr_reader, io::stderr());
-                    });
-                }
+				thread::spawn(move || {
+					let stdin = io::stdin();
+					let reader = stdin.lock();
 
-                // Wait for the child process to complete
-                match child.wait() {
-                    Ok(status) => std::process::exit(status.code().unwrap_or(1)),
-                    Err(e) => {
-                        eprintln!("Failed to wait for child process: {}", e);
-                        std::process::exit(1);
-                    }
-                }
-            }
-            Err(e) => {
-                eprintln!("Failed to execute command: {}", e);
-                std::process::exit(1);
-            }
-        }
+					for line in reader.lines() {
+						if let Ok(line) = line {
+							if let Ok(mut child_stdin) = stdin_clone.lock() {
+								let timestamp = get_timestamp();
+								let _ = writeln!(child_stdin, "{}{}", timestamp, line);
+							}
+						}
+					}
+				});
+			}
+
+			// Handle stdout
+			if let Some(stdout) = child.stdout.take() {
+				let stdout_reader = BufReader::new(stdout);
+				thread::spawn(move || {
+					process_stream(stdout_reader, io::stdout());
+				});
+			}
+
+			// Handle stderr
+			if let Some(stderr) = child.stderr.take() {
+				let stderr_reader = BufReader::new(stderr);
+				thread::spawn(move || {
+					process_stream(stderr_reader, io::stderr());
+				});
+			}
+
+			// Wait for the child process to complete
+			match child.wait() {
+				Ok(status) => std::process::exit(status.code().unwrap_or(1)),
+				Err(e) => {
+					eprintln!("Failed to wait for child process: {}", e);
+					std::process::exit(1);
+				}
+			}
+		}
+		Err(e) => {
+			eprintln!("Failed to execute command: {}", e);
+			std::process::exit(1);
+		}
+	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,124 +10,124 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 static mut CHILD_PID: Pid = Pid::from_raw(-1);
 const UNCHECKED_SIGNALS: [Signal; 5] = [
-        Signal::SIGTTIN,
-        Signal::SIGKILL,
-        Signal::SIGSTOP,
-        Signal::SIGCHLD,
-        Signal::SIGSEGV,
+	Signal::SIGTTIN,
+	Signal::SIGKILL,
+	Signal::SIGSTOP,
+	Signal::SIGCHLD,
+	Signal::SIGSEGV,
 ];
 
 extern "C" fn handle_signal(signum: c_int) {
-        unsafe {
-                assert!(CHILD_PID.as_raw() != -1, "child pid not set!");
-                let signal = std::mem::transmute::<i32, Signal>(signum as i32);
-                let _ = signal::kill(CHILD_PID, signal);
-        }
+	unsafe {
+		assert!(CHILD_PID.as_raw() != -1, "child pid not set!");
+		let signal = std::mem::transmute::<i32, Signal>(signum as i32);
+		let _ = signal::kill(CHILD_PID, signal);
+	}
 }
 
 fn get_timestamp() -> String {
-        let now = SystemTime::now();
-        let since_epoch = now.duration_since(UNIX_EPOCH).expect("Time went backwards");
-        format!("[{}] ", since_epoch.as_secs())
+	let now = SystemTime::now();
+	let since_epoch = now.duration_since(UNIX_EPOCH).expect("Time went backwards");
+	format!("[{}] ", since_epoch.as_secs())
 }
 
 fn process_stream<R: BufRead, W: Write>(reader: R, mut writer: W) {
-        for line in reader.lines() {
-                if let Ok(line) = line {
-                        let timestamp = get_timestamp();
-                        let _ = writeln!(writer, "{}{}", timestamp, line);
-                }
-        }
+	for line in reader.lines() {
+		if let Ok(line) = line {
+			let timestamp = get_timestamp();
+			let _ = writeln!(writer, "{}{}", timestamp, line);
+		}
+	}
 }
 
 fn main() {
-        let args: Vec<String> = args().skip(1).collect();
+	let args: Vec<String> = args().skip(1).collect();
 
-        if args.is_empty() {
-                eprintln!("Usage: qrun <command> [args...]");
-                std::process::exit(1);
-        }
+	if args.is_empty() {
+		eprintln!("Usage: qrun <command> [args...]");
+		std::process::exit(1);
+	}
 
-        // Create a command with piped stdin/stdout/stderr
-        let mut cmd = Command::new(&args[0]);
-        if args.len() > 1 {
-                cmd.args(&args[1..]);
-        }
+	// Create a command with piped stdin/stdout/stderr
+	let mut cmd = Command::new(&args[0]);
+	if args.len() > 1 {
+		cmd.args(&args[1..]);
+	}
 
-        cmd.stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped());
+	cmd.stdin(Stdio::piped())
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped());
 
-        match cmd.spawn() {
-                Ok(mut child) => {
-                        unsafe {
-                                CHILD_PID = Pid::from_raw(child.id() as i32);
-                        }
+	match cmd.spawn() {
+		Ok(mut child) => {
+			unsafe {
+				CHILD_PID = Pid::from_raw(child.id() as i32);
+			}
 
-                        let handler = SigHandler::Handler(handle_signal);
+			let handler = SigHandler::Handler(handle_signal);
 
-                        for sig in Signal::iterator() {
-                                if UNCHECKED_SIGNALS.contains(&sig) {
-                                        continue;
-                                }
+			for sig in Signal::iterator() {
+				if UNCHECKED_SIGNALS.contains(&sig) {
+					continue;
+				}
 
-                                unsafe {
-                                        let _ = sigaction(
-                                                sig,
-                                                &SigAction::new(handler, signal::SaFlags::empty(), SigSet::empty()),
-                                        );
-                                }
-                        }
+				unsafe {
+					let _ = sigaction(
+						sig,
+						&SigAction::new(handler, signal::SaFlags::empty(), SigSet::empty()),
+					);
+				}
+			}
 
-                        // Handle stdin
-                        let stdin = child.stdin.take();
-                        if let Some(stdin) = stdin {
-                                let stdin_mutex = Arc::new(Mutex::new(stdin));
-                                let stdin_clone = Arc::clone(&stdin_mutex);
+			// Handle stdin
+			let stdin = child.stdin.take();
+			if let Some(stdin) = stdin {
+				let stdin_mutex = Arc::new(Mutex::new(stdin));
+				let stdin_clone = Arc::clone(&stdin_mutex);
 
-                                thread::spawn(move || {
-                                        let stdin = io::stdin();
-                                        let reader = stdin.lock();
+				thread::spawn(move || {
+					let stdin = io::stdin();
+					let reader = stdin.lock();
 
-                                        for line in reader.lines() {
-                                                if let Ok(line) = line {
-                                                        if let Ok(mut child_stdin) = stdin_clone.lock() {
-                                                                let timestamp = get_timestamp();
-                                                                let _ = writeln!(child_stdin, "{}{}", timestamp, line);
-                                                        }
-                                                }
-                                        }
-                                });
-                        }
+					for line in reader.lines() {
+						if let Ok(line) = line {
+							if let Ok(mut child_stdin) = stdin_clone.lock() {
+								let timestamp = get_timestamp();
+								let _ = writeln!(child_stdin, "{}{}", timestamp, line);
+							}
+						}
+					}
+				});
+			}
 
-                        // Handle stdout
-                        if let Some(stdout) = child.stdout.take() {
-                                let stdout_reader = BufReader::new(stdout);
-                                thread::spawn(move || {
-                                        process_stream(stdout_reader, io::stdout());
-                                });
-                        }
+			// Handle stdout
+			if let Some(stdout) = child.stdout.take() {
+				let stdout_reader = BufReader::new(stdout);
+				thread::spawn(move || {
+					process_stream(stdout_reader, io::stdout());
+				});
+			}
 
-                        // Handle stderr
-                        if let Some(stderr) = child.stderr.take() {
-                                let stderr_reader = BufReader::new(stderr);
-                                thread::spawn(move || {
-                                        process_stream(stderr_reader, io::stderr());
-                                });
-                        }
+			// Handle stderr
+			if let Some(stderr) = child.stderr.take() {
+				let stderr_reader = BufReader::new(stderr);
+				thread::spawn(move || {
+					process_stream(stderr_reader, io::stderr());
+				});
+			}
 
-                        // Wait for the child process to complete
-                        match child.wait() {
-                                Ok(status) => std::process::exit(status.code().unwrap_or(1)),
-                                Err(e) => {
-                                        eprintln!("Failed to wait for child process: {}", e);
-                                        std::process::exit(1);
-                                }
-                        }
-                }
-                Err(e) => {
-                        eprintln!("Failed to execute command: {}", e);
-                        std::process::exit(1);
-                }
-        }
+			// Wait for the child process to complete
+			match child.wait() {
+				Ok(status) => std::process::exit(status.code().unwrap_or(1)),
+				Err(e) => {
+					eprintln!("Failed to wait for child process: {}", e);
+					std::process::exit(1);
+				}
+			}
+		}
+		Err(e) => {
+			eprintln!("Failed to execute command: {}", e);
+			std::process::exit(1);
+		}
+	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,63 +1,126 @@
-use fork::{daemon, Fork};
 use nix::libc::c_int;
 use nix::sys::signal::{self, sigaction, SigAction, SigHandler, SigSet, Signal};
 use nix::unistd::Pid;
-use nix::sys::wait::waitpid;
 use std::env::args;
-use std::io::Write;
-use std::os::unix::process::CommandExt;
-use std::process::Command;
+use std::io::{self, BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use chrono::Utc;
 
 static mut CHILD_PID: Pid = Pid::from_raw(-1);
 const UNCHECKED_SIGNALS: [Signal; 5] = [Signal::SIGTTIN, Signal::SIGKILL, Signal::SIGSTOP, Signal::SIGCHLD, Signal::SIGSEGV];
 
 extern "C" fn handle_signal(signum: c_int) {
-	unsafe {
-		assert!(CHILD_PID.as_raw() != -1, "child pid not set!");
-		let signal = std::mem::transmute::<i32, Signal>(signum as i32);
-		let _ = signal::kill(CHILD_PID, signal);
-	}
+        unsafe {
+                assert!(CHILD_PID.as_raw() != -1, "child pid not set!");
+                let signal = std::mem::transmute::<i32, Signal>(signum as i32);
+                let _ = signal::kill(CHILD_PID, signal);
+        }
+}
+
+fn get_timestamp() -> String {
+    let now = Utc::now();
+    format!("[{}] ", now.timestamp())
+}
+
+fn process_stream<R: BufRead, W: Write>(reader: R, mut writer: W) {
+    for line in reader.lines() {
+        if let Ok(line) = line {
+            let timestamp = get_timestamp();
+            let _ = writeln!(writer, "{}{}", timestamp, line);
+        }
+    }
 }
 
 fn main() {
-	let args: Vec<String> = args().skip(1).collect();
+        let args: Vec<String> = args().skip(1).collect();
 
-	match daemon(true, true) {
-		Ok(Fork::Child) => {
-			//TODO: SIGTTIN handler for input highlighting
-			let _ = Command::new("zsh")
-				.args(std::iter::once("-c".to_string()).chain(args.into_iter().skip(1)))
-				.exec();
+        if args.is_empty() {
+            eprintln!("Usage: qrun <command> [args...]");
+            std::process::exit(1);
+        }
 
-			std::process::exit(1);
-		}
-		Ok(Fork::Parent(pid)) => {
-			unsafe {
-				CHILD_PID = Pid::from_raw(pid);
-			}
+        // Create a command with piped stdin/stdout/stderr
+        let mut cmd = Command::new(&args[0]);
+        if args.len() > 1 {
+            cmd.args(&args[1..]);
+        }
+        
+        cmd.stdin(Stdio::piped())
+           .stdout(Stdio::piped())
+           .stderr(Stdio::piped());
 
-			let handler = SigHandler::Handler(handle_signal);
+        match cmd.spawn() {
+            Ok(mut child) => {
+                unsafe {
+                    CHILD_PID = Pid::from_raw(child.id() as i32);
+                }
 
-			for sig in Signal::iterator() {
-				if UNCHECKED_SIGNALS.contains(&sig) {
-					continue;
-				}
+                let handler = SigHandler::Handler(handle_signal);
 
-				unsafe {
-					let _ = sigaction(
-						sig,
-						&SigAction::new(handler, signal::SaFlags::empty(), SigSet::empty()),
-					);
-				}
-			}
+                for sig in Signal::iterator() {
+                    if UNCHECKED_SIGNALS.contains(&sig) {
+                        continue;
+                    }
 
-			let _ = waitpid(Pid::from_raw(pid), None);
-		}
-		Err(e) => {
-			std::io::stderr()
-				.write_all(format!("qrun failed to fork: {}", e).as_bytes())
-				.expect("qrun failed to write to stderr");
-			std::process::exit(1);
-		}
-	}
+                    unsafe {
+                        let _ = sigaction(
+                            sig,
+                            &SigAction::new(handler, signal::SaFlags::empty(), SigSet::empty()),
+                        );
+                    }
+                }
+
+                // Handle stdin
+                let stdin = child.stdin.take();
+                if let Some(stdin) = stdin {
+                    let stdin_mutex = Arc::new(Mutex::new(stdin));
+                    let stdin_clone = Arc::clone(&stdin_mutex);
+                    
+                    thread::spawn(move || {
+                        let stdin = io::stdin();
+                        let reader = stdin.lock();
+                        
+                        for line in reader.lines() {
+                            if let Ok(line) = line {
+                                if let Ok(mut child_stdin) = stdin_clone.lock() {
+                                    let timestamp = get_timestamp();
+                                    let _ = writeln!(child_stdin, "{}{}", timestamp, line);
+                                }
+                            }
+                        }
+                    });
+                }
+
+                // Handle stdout
+                if let Some(stdout) = child.stdout.take() {
+                    let stdout_reader = BufReader::new(stdout);
+                    thread::spawn(move || {
+                        process_stream(stdout_reader, io::stdout());
+                    });
+                }
+
+                // Handle stderr
+                if let Some(stderr) = child.stderr.take() {
+                    let stderr_reader = BufReader::new(stderr);
+                    thread::spawn(move || {
+                        process_stream(stderr_reader, io::stderr());
+                    });
+                }
+
+                // Wait for the child process to complete
+                match child.wait() {
+                    Ok(status) => std::process::exit(status.code().unwrap_or(1)),
+                    Err(e) => {
+                        eprintln!("Failed to wait for child process: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("Failed to execute command: {}", e);
+                std::process::exit(1);
+            }
+        }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
+use fork::{daemon, Fork};
 use nix::libc::c_int;
 use nix::sys::signal::{self, sigaction, SigAction, SigHandler, SigSet, Signal};
+use nix::sys::wait::waitpid;
 use nix::unistd::Pid;
 use std::env::args;
 use std::io::{self, BufRead, BufReader, Write};
+
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -48,20 +51,75 @@ fn main() {
 		std::process::exit(1);
 	}
 
-	// Create a command with piped stdin/stdout/stderr
-	let mut cmd = Command::new(&args[0]);
-	if args.len() > 1 {
-		cmd.args(&args[1..]);
-	}
+	match daemon(true, true) {
+		Ok(Fork::Child) => {
+			// Create a command with piped stdin/stdout/stderr
+			let mut cmd = Command::new(&args[0]);
+			if args.len() > 1 {
+				cmd.args(&args[1..]);
+			}
 
-	cmd.stdin(Stdio::piped())
-		.stdout(Stdio::piped())
-		.stderr(Stdio::piped());
+			cmd.stdin(Stdio::piped())
+				.stdout(Stdio::piped())
+				.stderr(Stdio::piped());
 
-	match cmd.spawn() {
-		Ok(mut child) => {
+			match cmd.spawn() {
+				Ok(mut child) => {
+					// Handle stdin
+					let stdin = child.stdin.take();
+					if let Some(stdin) = stdin {
+						let stdin_mutex = Arc::new(Mutex::new(stdin));
+						let stdin_clone = Arc::clone(&stdin_mutex);
+
+						thread::spawn(move || {
+							let stdin = io::stdin();
+							let reader = stdin.lock();
+
+							for line in reader.lines() {
+								if let Ok(line) = line {
+									if let Ok(mut child_stdin) = stdin_clone.lock() {
+										let timestamp = get_unix_timestamp();
+										let _ = writeln!(child_stdin, "[{}] {}", timestamp, line);
+									}
+								}
+							}
+						});
+					}
+
+					// Handle stdout
+					if let Some(stdout) = child.stdout.take() {
+						let stdout_reader = BufReader::new(stdout);
+						thread::spawn(move || {
+							process_stream(stdout_reader, io::stdout());
+						});
+					}
+
+					// Handle stderr
+					if let Some(stderr) = child.stderr.take() {
+						let stderr_reader = BufReader::new(stderr);
+						thread::spawn(move || {
+							process_stream(stderr_reader, io::stderr());
+						});
+					}
+
+					// Wait for the child process to complete
+					match child.wait() {
+						Ok(status) => std::process::exit(status.code().unwrap_or(1)),
+						Err(e) => {
+							eprintln!("Failed to wait for child process: {}", e);
+							std::process::exit(1);
+						}
+					}
+				}
+				Err(e) => {
+					eprintln!("Failed to execute command: {}", e);
+					std::process::exit(1);
+				}
+			}
+		}
+		Ok(Fork::Parent(pid)) => {
 			unsafe {
-				CHILD_PID = Pid::from_raw(child.id() as i32);
+				CHILD_PID = Pid::from_raw(pid);
 			}
 
 			let handler = SigHandler::Handler(handle_signal);
@@ -79,54 +137,10 @@ fn main() {
 				}
 			}
 
-			// Handle stdin
-			let stdin = child.stdin.take();
-			if let Some(stdin) = stdin {
-				let stdin_mutex = Arc::new(Mutex::new(stdin));
-				let stdin_clone = Arc::clone(&stdin_mutex);
-
-				thread::spawn(move || {
-					let stdin = io::stdin();
-					let reader = stdin.lock();
-
-					for line in reader.lines() {
-						if let Ok(line) = line {
-							if let Ok(mut child_stdin) = stdin_clone.lock() {
-								let timestamp = get_unix_timestamp();
-								let _ = writeln!(child_stdin, "[{}] {}", timestamp, line);
-							}
-						}
-					}
-				});
-			}
-
-			// Handle stdout
-			if let Some(stdout) = child.stdout.take() {
-				let stdout_reader = BufReader::new(stdout);
-				thread::spawn(move || {
-					process_stream(stdout_reader, io::stdout());
-				});
-			}
-
-			// Handle stderr
-			if let Some(stderr) = child.stderr.take() {
-				let stderr_reader = BufReader::new(stderr);
-				thread::spawn(move || {
-					process_stream(stderr_reader, io::stderr());
-				});
-			}
-
-			// Wait for the child process to complete
-			match child.wait() {
-				Ok(status) => std::process::exit(status.code().unwrap_or(1)),
-				Err(e) => {
-					eprintln!("Failed to wait for child process: {}", e);
-					std::process::exit(1);
-				}
-			}
+			let _ = waitpid(Pid::from_raw(pid), None);
 		}
 		Err(e) => {
-			eprintln!("Failed to execute command: {}", e);
+			eprintln!("qrun failed to fork: {}", e);
 			std::process::exit(1);
 		}
 	}

--- a/tests/timestamp_test.rs
+++ b/tests/timestamp_test.rs
@@ -4,121 +4,161 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
 fn test_timestamp_format() {
-	// Create a simple command that echoes a test string
-	let mut cmd = Command::new("target/debug/qrun")
-		.arg("echo")
-		.arg("Test output")
-		.stdout(Stdio::piped())
-		.spawn()
-		.expect("Failed to start qrun");
+        // Create a simple command that echoes a test string
+        let mut cmd = Command::new("target/debug/qrun")
+                .arg("echo")
+                .arg("Test output")
+                .stdout(Stdio::piped())
+                .spawn()
+                .expect("Failed to start qrun");
 
-	// Get the output
-	let output = cmd.stdout.take().expect("Failed to open stdout");
-	let reader = BufReader::new(output);
-	let lines: Vec<String> = reader.lines().collect::<Result<_, _>>().unwrap();
+        // Get the output
+        let output = cmd.stdout.take().expect("Failed to open stdout");
+        let reader = BufReader::new(output);
+        let lines: Vec<String> = reader.lines().collect::<Result<_, _>>().unwrap();
 
-	// There should be exactly one line of output
-	assert_eq!(lines.len(), 1, "Expected exactly one line of output");
+        // There should be exactly one line of output
+        assert_eq!(lines.len(), 1, "Expected exactly one line of output");
 
-	// The line should start with a timestamp in the format [timestamp]
-	let line = &lines[0];
-	let timestamp_regex = regex::Regex::new(r"^\[\d+\] Test output$").unwrap();
-	assert!(
-		timestamp_regex.is_match(line),
-		"Output does not match expected format: {}",
-		line
-	);
+        // The line should start with a timestamp in the format [timestamp]
+        let line = &lines[0];
+        let timestamp_regex = regex::Regex::new(r"^\[\d+\] Test output$").unwrap();
+        assert!(
+                timestamp_regex.is_match(line),
+                "Output does not match expected format: {}",
+                line
+        );
 
-	// Extract the timestamp and verify it's a valid Unix timestamp
-	let timestamp_str = line
-		.trim_start_matches('[')
-		.split(']')
-		.next()
-		.expect("Failed to extract timestamp");
+        // Extract the timestamp and verify it's a valid Unix timestamp
+        let timestamp_str = line
+                .trim_start_matches('[')
+                .split(']')
+                .next()
+                .expect("Failed to extract timestamp");
 
-	let timestamp: u64 = timestamp_str
-		.parse()
-		.expect("Failed to parse timestamp as u64");
+        let timestamp: u64 = timestamp_str
+                .parse()
+                .expect("Failed to parse timestamp as u64");
 
-	// Get the current timestamp
-	let now = SystemTime::now()
-		.duration_since(UNIX_EPOCH)
-		.expect("Time went backwards")
-		.as_secs();
+        // Get the current timestamp
+        let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went backwards")
+                .as_secs();
 
-	// The timestamp should be close to the current time (within 10 seconds)
-	assert!(
-		now.abs_diff(timestamp) < 10,
-		"Timestamp {} is not close to current time {}",
-		timestamp,
-		now
-	);
+        // The timestamp should be close to the current time (within 10 seconds)
+        assert!(
+                now.abs_diff(timestamp) < 10,
+                "Timestamp {} is not close to current time {}",
+                timestamp,
+                now
+        );
 }
 
 #[test]
 fn test_timestamp_added_to_stdin() {
-	// Create a command that will read from stdin and echo to stdout
-	let mut cmd = Command::new("target/debug/qrun")
-		.arg("cat")
-		.stdin(Stdio::piped())
-		.stdout(Stdio::piped())
-		.spawn()
-		.expect("Failed to start qrun");
+        // Create a command that will read from stdin and echo to stdout
+        let mut cmd = Command::new("target/debug/qrun")
+                .arg("cat")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .expect("Failed to start qrun");
 
-	// Write to stdin
-	let test_input = "Test input";
-	{
-		let mut stdin = cmd.stdin.take().expect("Failed to open stdin");
-		stdin
-			.write_all(test_input.as_bytes())
-			.expect("Failed to write to stdin");
-		// stdin is closed when it goes out of scope
-	}
+        // Write to stdin
+        let test_input = "Test input";
+        {
+                let mut stdin = cmd.stdin.take().expect("Failed to open stdin");
+                stdin
+                        .write_all(test_input.as_bytes())
+                        .expect("Failed to write to stdin");
+                // stdin is closed when it goes out of scope
+        }
 
-	// Get the output
-	let output = cmd.stdout.take().expect("Failed to open stdout");
-	let reader = BufReader::new(output);
-	let lines: Vec<String> = reader.lines().collect::<Result<_, _>>().unwrap();
+        // Get the output
+        let output = cmd.stdout.take().expect("Failed to open stdout");
+        let reader = BufReader::new(output);
+        let lines: Vec<String> = reader.lines().collect::<Result<_, _>>().unwrap();
 
-	// There should be exactly one line of output
-	assert_eq!(lines.len(), 1, "Expected exactly one line of output");
+        // There should be exactly one line of output
+        assert_eq!(lines.len(), 1, "Expected exactly one line of output");
 
-	// The line should have timestamps in the format [timestamp] [timestamp] Test input
-	// This is because qrun adds a timestamp to stdin and then cat outputs that line,
-	// which qrun then adds another timestamp to
-	let line = &lines[0];
-	let timestamp_regex = regex::Regex::new(r"^\[\d+\] \[\d+\] Test input$").unwrap();
-	assert!(
-		timestamp_regex.is_match(line),
-		"Output does not match expected format: {}",
-		line
-	);
+        // The line should have timestamps in the format [timestamp] [timestamp] Test input
+        // This is because qrun adds a timestamp to stdin and then cat outputs that line,
+        // which qrun then adds another timestamp to
+        let line = &lines[0];
+        let timestamp_regex = regex::Regex::new(r"^\[\d+\] \[\d+\] Test input$").unwrap();
+        assert!(
+                timestamp_regex.is_match(line),
+                "Output does not match expected format: {}",
+                line
+        );
 }
 
 #[test]
 fn test_timestamp_added_to_stderr() {
-	// Create a command that will output to stderr
-	let output = Command::new("target/debug/qrun")
-		.arg("sh")
-		.arg("-c")
-		.arg("echo 'Error message' >&2")
-		.stderr(Stdio::piped())
-		.output()
-		.expect("Failed to start qrun");
+        // Create a command that will output to stderr
+        let output = Command::new("target/debug/qrun")
+                .arg("sh")
+                .arg("-c")
+                .arg("echo 'Error message' >&2")
+                .stderr(Stdio::piped())
+                .output()
+                .expect("Failed to start qrun");
 
-	// Convert stderr to string
-	let stderr = String::from_utf8_lossy(&output.stderr);
-	let lines: Vec<&str> = stderr.lines().collect();
+        // Convert stderr to string
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let lines: Vec<&str> = stderr.lines().collect();
 
-	// There should be exactly one line of output
-	assert_eq!(lines.len(), 1, "Expected exactly one line of stderr output");
+        // There should be exactly one line of output
+        assert_eq!(lines.len(), 1, "Expected exactly one line of stderr output");
 
-	// The line should start with a timestamp in the format [timestamp]
-	let line = lines[0];
-	let timestamp_regex = regex::Regex::new(r"^\[\d+\] Error message$").unwrap();
-	assert!(
-		timestamp_regex.is_match(line),
-		"Stderr output does not match expected format: {}",
-		line
-	);
+        // The line should start with a timestamp in the format [timestamp]
+        let line = lines[0];
+        let timestamp_regex = regex::Regex::new(r"^\[\d+\] Error message$").unwrap();
+        assert!(
+                timestamp_regex.is_match(line),
+                "Stderr output does not match expected format: {}",
+                line
+        );
+}
+
+#[test]
+fn test_timestamp_added_to_multiline_output() {
+        // Create a command that will output multiple lines
+        let output = Command::new("target/debug/qrun")
+                .arg("printf")
+                .arg("Line 1\nLine 2\nLine 3\n")
+                .stdout(Stdio::piped())
+                .output()
+                .expect("Failed to start qrun");
+
+        // Convert stdout to string
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let lines: Vec<&str> = stdout.lines().collect();
+
+        // There should be exactly three lines of output
+        assert_eq!(lines.len(), 3, "Expected exactly three lines of output");
+
+        // Each line should start with a timestamp in the format [timestamp]
+        let timestamp_regex = regex::Regex::new(r"^\[\d+\] Line \d$").unwrap();
+
+        for (i, line) in lines.iter().enumerate() {
+                let expected_line_num = i + 1;
+                assert!(
+                        timestamp_regex.is_match(line),
+                        "Line {} does not match expected format: {}",
+                        expected_line_num,
+                        line
+                );
+
+                // Verify the line number in the content matches the expected line number
+                let content = line.split("] ").nth(1).unwrap();
+                assert_eq!(
+                        content,
+                        format!("Line {}", expected_line_num),
+                        "Line content does not match expected: {}",
+                        content
+                );
+        }
 }

--- a/tests/timestamp_test.rs
+++ b/tests/timestamp_test.rs
@@ -4,117 +4,121 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
 fn test_timestamp_format() {
-    // Create a simple command that echoes a test string
-    let mut cmd = Command::new("target/debug/qrun")
-        .arg("echo")
-        .arg("Test output")
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("Failed to start qrun");
+	// Create a simple command that echoes a test string
+	let mut cmd = Command::new("target/debug/qrun")
+		.arg("echo")
+		.arg("Test output")
+		.stdout(Stdio::piped())
+		.spawn()
+		.expect("Failed to start qrun");
 
-    // Get the output
-    let output = cmd.stdout.take().expect("Failed to open stdout");
-    let reader = BufReader::new(output);
-    let lines: Vec<String> = reader.lines().collect::<Result<_, _>>().unwrap();
+	// Get the output
+	let output = cmd.stdout.take().expect("Failed to open stdout");
+	let reader = BufReader::new(output);
+	let lines: Vec<String> = reader.lines().collect::<Result<_, _>>().unwrap();
 
-    // There should be exactly one line of output
-    assert_eq!(lines.len(), 1, "Expected exactly one line of output");
+	// There should be exactly one line of output
+	assert_eq!(lines.len(), 1, "Expected exactly one line of output");
 
-    // The line should start with a timestamp in the format [timestamp]
-    let line = &lines[0];
-    let timestamp_regex = regex::Regex::new(r"^\[\d+\] Test output$").unwrap();
-    assert!(
-        timestamp_regex.is_match(line),
-        "Output does not match expected format: {}",
-        line
-    );
+	// The line should start with a timestamp in the format [timestamp]
+	let line = &lines[0];
+	let timestamp_regex = regex::Regex::new(r"^\[\d+\] Test output$").unwrap();
+	assert!(
+		timestamp_regex.is_match(line),
+		"Output does not match expected format: {}",
+		line
+	);
 
-    // Extract the timestamp and verify it's a valid Unix timestamp
-    let timestamp_str = line
-        .trim_start_matches('[')
-        .split(']')
-        .next()
-        .expect("Failed to extract timestamp");
-    
-    let timestamp: u64 = timestamp_str.parse().expect("Failed to parse timestamp as u64");
-    
-    // Get the current timestamp
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards")
-        .as_secs();
-    
-    // The timestamp should be close to the current time (within 10 seconds)
-    assert!(
-        now.abs_diff(timestamp) < 10,
-        "Timestamp {} is not close to current time {}",
-        timestamp,
-        now
-    );
+	// Extract the timestamp and verify it's a valid Unix timestamp
+	let timestamp_str = line
+		.trim_start_matches('[')
+		.split(']')
+		.next()
+		.expect("Failed to extract timestamp");
+
+	let timestamp: u64 = timestamp_str
+		.parse()
+		.expect("Failed to parse timestamp as u64");
+
+	// Get the current timestamp
+	let now = SystemTime::now()
+		.duration_since(UNIX_EPOCH)
+		.expect("Time went backwards")
+		.as_secs();
+
+	// The timestamp should be close to the current time (within 10 seconds)
+	assert!(
+		now.abs_diff(timestamp) < 10,
+		"Timestamp {} is not close to current time {}",
+		timestamp,
+		now
+	);
 }
 
 #[test]
 fn test_timestamp_added_to_stdin() {
-    // Create a command that will read from stdin and echo to stdout
-    let mut cmd = Command::new("target/debug/qrun")
-        .arg("cat")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("Failed to start qrun");
+	// Create a command that will read from stdin and echo to stdout
+	let mut cmd = Command::new("target/debug/qrun")
+		.arg("cat")
+		.stdin(Stdio::piped())
+		.stdout(Stdio::piped())
+		.spawn()
+		.expect("Failed to start qrun");
 
-    // Write to stdin
-    let test_input = "Test input";
-    {
-        let mut stdin = cmd.stdin.take().expect("Failed to open stdin");
-        stdin.write_all(test_input.as_bytes()).expect("Failed to write to stdin");
-        // stdin is closed when it goes out of scope
-    }
+	// Write to stdin
+	let test_input = "Test input";
+	{
+		let mut stdin = cmd.stdin.take().expect("Failed to open stdin");
+		stdin
+			.write_all(test_input.as_bytes())
+			.expect("Failed to write to stdin");
+		// stdin is closed when it goes out of scope
+	}
 
-    // Get the output
-    let output = cmd.stdout.take().expect("Failed to open stdout");
-    let reader = BufReader::new(output);
-    let lines: Vec<String> = reader.lines().collect::<Result<_, _>>().unwrap();
+	// Get the output
+	let output = cmd.stdout.take().expect("Failed to open stdout");
+	let reader = BufReader::new(output);
+	let lines: Vec<String> = reader.lines().collect::<Result<_, _>>().unwrap();
 
-    // There should be exactly one line of output
-    assert_eq!(lines.len(), 1, "Expected exactly one line of output");
+	// There should be exactly one line of output
+	assert_eq!(lines.len(), 1, "Expected exactly one line of output");
 
-    // The line should have timestamps in the format [timestamp] [timestamp] Test input
-    // This is because qrun adds a timestamp to stdin and then cat outputs that line,
-    // which qrun then adds another timestamp to
-    let line = &lines[0];
-    let timestamp_regex = regex::Regex::new(r"^\[\d+\] \[\d+\] Test input$").unwrap();
-    assert!(
-        timestamp_regex.is_match(line),
-        "Output does not match expected format: {}",
-        line
-    );
+	// The line should have timestamps in the format [timestamp] [timestamp] Test input
+	// This is because qrun adds a timestamp to stdin and then cat outputs that line,
+	// which qrun then adds another timestamp to
+	let line = &lines[0];
+	let timestamp_regex = regex::Regex::new(r"^\[\d+\] \[\d+\] Test input$").unwrap();
+	assert!(
+		timestamp_regex.is_match(line),
+		"Output does not match expected format: {}",
+		line
+	);
 }
 
 #[test]
 fn test_timestamp_added_to_stderr() {
-    // Create a command that will output to stderr
-    let output = Command::new("target/debug/qrun")
-        .arg("sh")
-        .arg("-c")
-        .arg("echo 'Error message' >&2")
-        .stderr(Stdio::piped())
-        .output()
-        .expect("Failed to start qrun");
+	// Create a command that will output to stderr
+	let output = Command::new("target/debug/qrun")
+		.arg("sh")
+		.arg("-c")
+		.arg("echo 'Error message' >&2")
+		.stderr(Stdio::piped())
+		.output()
+		.expect("Failed to start qrun");
 
-    // Convert stderr to string
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let lines: Vec<&str> = stderr.lines().collect();
+	// Convert stderr to string
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	let lines: Vec<&str> = stderr.lines().collect();
 
-    // There should be exactly one line of output
-    assert_eq!(lines.len(), 1, "Expected exactly one line of stderr output");
+	// There should be exactly one line of output
+	assert_eq!(lines.len(), 1, "Expected exactly one line of stderr output");
 
-    // The line should start with a timestamp in the format [timestamp]
-    let line = lines[0];
-    let timestamp_regex = regex::Regex::new(r"^\[\d+\] Error message$").unwrap();
-    assert!(
-        timestamp_regex.is_match(line),
-        "Stderr output does not match expected format: {}",
-        line
-    );
+	// The line should start with a timestamp in the format [timestamp]
+	let line = lines[0];
+	let timestamp_regex = regex::Regex::new(r"^\[\d+\] Error message$").unwrap();
+	assert!(
+		timestamp_regex.is_match(line),
+		"Stderr output does not match expected format: {}",
+		line
+	);
 }

--- a/tests/timestamp_test.rs
+++ b/tests/timestamp_test.rs
@@ -1,0 +1,120 @@
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn test_timestamp_format() {
+    // Create a simple command that echoes a test string
+    let mut cmd = Command::new("target/debug/qrun")
+        .arg("echo")
+        .arg("Test output")
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to start qrun");
+
+    // Get the output
+    let output = cmd.stdout.take().expect("Failed to open stdout");
+    let reader = BufReader::new(output);
+    let lines: Vec<String> = reader.lines().collect::<Result<_, _>>().unwrap();
+
+    // There should be exactly one line of output
+    assert_eq!(lines.len(), 1, "Expected exactly one line of output");
+
+    // The line should start with a timestamp in the format [timestamp]
+    let line = &lines[0];
+    let timestamp_regex = regex::Regex::new(r"^\[\d+\] Test output$").unwrap();
+    assert!(
+        timestamp_regex.is_match(line),
+        "Output does not match expected format: {}",
+        line
+    );
+
+    // Extract the timestamp and verify it's a valid Unix timestamp
+    let timestamp_str = line
+        .trim_start_matches('[')
+        .split(']')
+        .next()
+        .expect("Failed to extract timestamp");
+    
+    let timestamp: u64 = timestamp_str.parse().expect("Failed to parse timestamp as u64");
+    
+    // Get the current timestamp
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_secs();
+    
+    // The timestamp should be close to the current time (within 10 seconds)
+    assert!(
+        now.abs_diff(timestamp) < 10,
+        "Timestamp {} is not close to current time {}",
+        timestamp,
+        now
+    );
+}
+
+#[test]
+fn test_timestamp_added_to_stdin() {
+    // Create a command that will read from stdin and echo to stdout
+    let mut cmd = Command::new("target/debug/qrun")
+        .arg("cat")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to start qrun");
+
+    // Write to stdin
+    let test_input = "Test input";
+    {
+        let mut stdin = cmd.stdin.take().expect("Failed to open stdin");
+        stdin.write_all(test_input.as_bytes()).expect("Failed to write to stdin");
+        // stdin is closed when it goes out of scope
+    }
+
+    // Get the output
+    let output = cmd.stdout.take().expect("Failed to open stdout");
+    let reader = BufReader::new(output);
+    let lines: Vec<String> = reader.lines().collect::<Result<_, _>>().unwrap();
+
+    // There should be exactly one line of output
+    assert_eq!(lines.len(), 1, "Expected exactly one line of output");
+
+    // The line should have timestamps in the format [timestamp] [timestamp] Test input
+    // This is because qrun adds a timestamp to stdin and then cat outputs that line,
+    // which qrun then adds another timestamp to
+    let line = &lines[0];
+    let timestamp_regex = regex::Regex::new(r"^\[\d+\] \[\d+\] Test input$").unwrap();
+    assert!(
+        timestamp_regex.is_match(line),
+        "Output does not match expected format: {}",
+        line
+    );
+}
+
+#[test]
+fn test_timestamp_added_to_stderr() {
+    // Create a command that will output to stderr
+    let output = Command::new("target/debug/qrun")
+        .arg("sh")
+        .arg("-c")
+        .arg("echo 'Error message' >&2")
+        .stderr(Stdio::piped())
+        .output()
+        .expect("Failed to start qrun");
+
+    // Convert stderr to string
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let lines: Vec<&str> = stderr.lines().collect();
+
+    // There should be exactly one line of output
+    assert_eq!(lines.len(), 1, "Expected exactly one line of stderr output");
+
+    // The line should start with a timestamp in the format [timestamp]
+    let line = lines[0];
+    let timestamp_regex = regex::Regex::new(r"^\[\d+\] Error message$").unwrap();
+    assert!(
+        timestamp_regex.is_match(line),
+        "Stderr output does not match expected format: {}",
+        line
+    );
+}


### PR DESCRIPTION
This PR adds a feature to add Unix timestamps to the beginning of every line in both stdin and stdout streams. The timestamp is in the format [timestamp] where timestamp is the Unix timestamp in seconds.

Changes:
- Used std::time for timestamp generation (no external dependencies)
- Implemented timestamp functionality for both stdin and stdout streams
- Refactored command execution to capture and process streams
- Formatted code with rustfmt
- Updated Cargo.lock to remove unnecessary dependencies
- Ensured consistent code formatting throughout
- Reverted unrelated dependency updates in Cargo.lock
- Optimized timestamp formatting by directly formatting in writeln!
- Added comprehensive tests for the timestamp feature
- Ensured all code, including tests, is properly formatted
- Added test for multiline output to verify timestamps are added to each line
- Restored original forking behavior while maintaining timestamp functionality
- Added benchmarks to measure performance overhead of timestamp feature